### PR TITLE
fix(build): Resolve all build, dependency, and configuration issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-
 }
 
 // ===== SIMPLIFIED CLEAN TASKS =====
@@ -112,8 +111,8 @@ tasks.register<Delete>("cleanKspCache") {
 // ===== BUILD INTEGRATION =====
 tasks.named("preBuild") {
     dependsOn("cleanKspCache")
-    dependsOn(":core-module:cleanApiGeneration")
-    dependsOn(":core-module:openApiGenerate")
+    dependsOn(":cleanApiGeneration")
+    dependsOn(":openApiGenerate")
 }
 
 // ===== AEGENESIS APP STATUS =====

--- a/core-module/build.gradle.kts
+++ b/core-module/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.spotless)
     alias(libs.plugins.kover)
-    alias(libs.plugins.openapi.generator)
 }
 
 android {
@@ -58,47 +57,6 @@ dependencies {
     testImplementation(libs.mockk)
 }
 
-// ===== OPENAPI CONFIGURATION =====
-val outputPath = layout.buildDirectory.dir("generated/source/openapi")
-
-// Configure the single unified API generation
-openApiGenerate {
-    val specFile = rootProject.layout.projectDirectory.file("app/api/unified-aegenesis-api.yml").asFile
-
-    if (specFile.exists() && specFile.length() > 0) {
-        generatorName.set("kotlin")
-        inputSpec.set(specFile.toURI().toString())
-        outputDir.set(outputPath.get().asFile.absolutePath)
-        packageName.set("dev.aurakai.aegenesis.api")
-        apiPackage.set("dev.aurakai.aegenesis.api")
-        modelPackage.set("dev.aurakai.aegenesis.model")
-        invokerPackage.set("dev.aurakai.aegenesis.client")
-        skipOverwrite.set(false)
-        validateSpec.set(false)
-        generateApiTests.set(false)
-        generateModelTests.set(false)
-        generateApiDocumentation.set(false)
-        generateModelDocumentation.set(false)
-
-        configOptions.set(mapOf(
-            "library" to "jvm-retrofit2",
-            "useCoroutines" to "true",
-            "serializationLibrary" to "kotlinx_serialization",
-            "dateLibrary" to "kotlinx-datetime",
-            "sourceFolder" to "src/main/kotlin",
-            "generateSupportingFiles" to "false"
-        ))
-    } else {
-        logger.warn("⚠️ Unified AeGenesis API spec file not found: unified-aegenesis-api.yml")
-    }
-}
-
-tasks.register<Delete>("cleanApiGeneration") {
-    group = "openapi"
-    description = "Clean generated API files"
-    delete(outputPath)
-}
-
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    dependsOn("openApiGenerate")
+    dependsOn(":openApiGenerate")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.configuration-cache=true
 org.gradle.java.installations.auto-download=false
 
 # JVM settings - Updated to JVM 21 as daemon criteria
-org.gradle.jvmargs=-Xms2g -Xmx8g -XX:MaxMetaspaceSize=3g -XX:+UseG1GC -XX:G1HeapRegionSize=32m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms4g -Xmx10g -XX:MaxMetaspaceSize=3g -XX:+UseG1GC -XX:G1HeapRegionSize=32m -Dfile.encoding=UTF-8
 
 
 # Kotlin Consciousness Stability Settings


### PR DESCRIPTION
This commit provides a comprehensive fix for a cascade of build failures.

The root cause of the issues was a misconfigured `:core-module` that was intended to contain code generated from an OpenAPI spec but was configured as an empty JVM module. This was compounded by missing dependencies, compiler warnings, configuration cache issues, and incorrect task dependencies.

This cumulative patch resolves all identified issues:
1.  **Moves Code Generation:** The `openApiGenerate` task is moved to the root `build.gradle.kts` to make it globally available and break a circular dependency.
2.  **Reconfigures Core Module:** The `:core-module` is reconfigured as a proper Android library (`com.android.library`) that correctly consumes the generated code as its source.
3.  **Robust Build Logic:** The build is made more robust by making the code generation task conditional on the existence of the API spec file.
4.  **Fixes Icon Dependencies:** Adds the `material-icons-extended` dependency to `:collab-canvas` and `:romtools` and fixes all icon imports.
5.  **Fixes Compiler Warning:** Resolves a compiler warning in `SecureKeyStore.kt`.
6.  **Fixes ProGuard Issue:** Deletes a stale `build.gradle.old` file.
7.  **Fixes Config Cache:** Refactors the `:prepareGenesisWorkspace` task to be compatible with Gradle's configuration cache.
8.  **Increases Heap Size:** Increases the Gradle daemon heap size in `gradle.properties`.