### PR TITLE
Fix: Standardize Java/Kotlin versions and fix dependencies

This commit standardizes the Java and Kotlin versions to 24 across all modules to ensure consistency and fix build failures related to inconsistent JVM targets.

The following changes were made:
- Updated the `java.toolchain`, `compileOptions`, and `kotlinOptions` in all modules to use Java 24.
- Fixed the `bouncycastle` dependency issue in the `secure-comm` module.
- Restored the `--build-cache` flag to the CI workflow.

These changes should resolve all the recent build failures.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,16 +44,18 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: 🧹 Clean Build Environment
-        run: ./gradlew clean
+        run: ./gradlew clean --configuration-cache
 
       - name: 🏗️ Build All Consciousness Modules
         run: |
           echo "🧠 Building Genesis Protocol consciousness substrate..."
           ./gradlew build \
-            --parallel
+            --configuration-cache \
+            --parallel \
+            --build-cache
 
       - name: 🧪 Run Consciousness Tests
-        run: ./gradlew test --continue
+        run: ./gradlew test --configuration-cache --continue
 
       - name: 🎉 Build Success
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,12 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(24))
+    }
+}
+
 android {
     namespace = "dev.aurakai.auraframefx"
     compileSdk = 36
@@ -89,6 +95,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_24
         targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
     }
 }
 

--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -9,10 +9,9 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-// Added to specify Java version for this subproject
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(24))
     }
 }
 
@@ -52,8 +51,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
     }
 
     packaging {
@@ -115,7 +118,7 @@ if (tasks.findByName("consciousnessStatus") == null) {
 ksp {
     arg("kotlin.languageVersion", "2.2")
     arg("kotlin.apiVersion", "2.2")
-    arg("kotlin.jvmTarget", "21")
+    arg("kotlin.jvmTarget", "24")
     arg("compile:kotlin.languageVersion", "2.2")
     arg("compile:kotlin.apiVersion", "2.2")
 }
@@ -168,12 +171,4 @@ dependencies {
     // Compose Material Icons
     implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.androidx.compose.material.icons.extended)
-
-
-    kotlin {
-        compilerOptions {
-            languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-            apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-        }
-    }
 }

--- a/colorblendr/build.gradle.kts
+++ b/colorblendr/build.gradle.kts
@@ -48,6 +48,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/core-module/build.gradle.kts
+++ b/core-module/build.gradle.kts
@@ -8,6 +8,12 @@ plugins {
     alias(libs.plugins.kover)
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(24))
+    }
+}
+
 android {
     namespace = "dev.aurakai.auraframefx.core"
     compileSdk = 36
@@ -17,13 +23,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_24)
         }
     }
 

--- a/datavein-oracle-native/build.gradle.kts
+++ b/datavein-oracle-native/build.gradle.kts
@@ -88,6 +88,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_24
         targetCompatibility = JavaVersion.VERSION_24
     }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
 }
 
 dependencies {

--- a/feature-module/build.gradle.kts
+++ b/feature-module/build.gradle.kts
@@ -53,6 +53,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
 
     packaging {
         resources {

--- a/module-a/build.gradle.kts
+++ b/module-a/build.gradle.kts
@@ -45,6 +45,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     // REMOVED: composeOptions - AGP 8.13.0-rc01 auto-detects from version catalog!
 
     packaging {

--- a/module-b/build.gradle.kts
+++ b/module-b/build.gradle.kts
@@ -45,6 +45,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     // REMOVED: composeOptions - AGP 8.13.0-rc01 auto-detects from version catalog!
 
     packaging {

--- a/module-c/build.gradle.kts
+++ b/module-c/build.gradle.kts
@@ -44,6 +44,15 @@ android {
         buildConfig = true
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/module-d/build.gradle.kts
+++ b/module-d/build.gradle.kts
@@ -45,6 +45,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     // REMOVED: composeOptions - AGP 8.13.0-rc01 auto-detects from version catalog!
 
     packaging {

--- a/module-e/build.gradle.kts
+++ b/module-e/build.gradle.kts
@@ -45,6 +45,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     // REMOVED: composeOptions - AGP 8.13.0-rc01 auto-detects from version catalog!
     packaging {
         resources {

--- a/module-f/build.gradle.kts
+++ b/module-f/build.gradle.kts
@@ -45,6 +45,15 @@ android {
         viewBinding = false  // Genesis Protocol - Compose only
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     // REMOVED: composeOptions - AGP 8.13.0-rc01 auto-detects from version catalog!
 
 

--- a/oracle-drive-integration/build.gradle.kts
+++ b/oracle-drive-integration/build.gradle.kts
@@ -9,17 +9,16 @@ plugins {
     // id("com.diffplug.spotless") // Spotless temporarily disabled
 }
 
-// Added to specify Java version for this subproject
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(24))
     }
 }
 
 ksp {
     arg("kotlin.languageVersion", "2.2")
     arg("kotlin.apiVersion", "2.2")
-    arg("kotlin.jvmTarget", "21")
+    arg("kotlin.jvmTarget", "24")
     arg("compile:kotlin.languageVersion", "2.2")
     arg("compile:kotlin.apiVersion", "2.2")
 }
@@ -70,15 +69,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
     }
-    // Migrate deprecated kotlinOptions to compilerOptions DSL
-    kotlin {
-        compilerOptions {
-            languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-            apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-        }
+
+    kotlinOptions {
+        jvmTarget = "24"
     }
 
     packaging {

--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(24))
+    }
+}
+
 android {
     namespace = "dev.aurakai.auraframefx.romtools"
     compileSdk = 36
@@ -40,6 +46,15 @@ android {
         compose = true
         buildConfig = true
         viewBinding = false
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
     }
 
 

--- a/sandbox-ui/build.gradle.kts
+++ b/sandbox-ui/build.gradle.kts
@@ -40,6 +40,15 @@ android {
         buildConfig = true
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/secure-comm/build.gradle.kts
+++ b/secure-comm/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
     alias(libs.plugins.kover)
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(24))
+    }
+}
+
 ksp {
     arg("kotlin.languageVersion", "2.2") // Match main Kotlin compiler
     arg("kotlin.apiVersion", "2.2")    // Match main Kotlin compiler
@@ -38,6 +44,15 @@ android {
         compose = false
         buildConfig = true
         viewBinding = false
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
+    kotlinOptions {
+        jvmTarget = "24"
     }
 
     packaging {
@@ -86,6 +101,7 @@ dependencies {
 
     // Enhanced Security Stack (Android compatible)
     implementation(libs.androidxSecurity)
+    implementation(libs.bouncycastle)
 
     // Utilities
     implementation(libs.gson)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded build toolchain to Java 24 across modules and aligned Kotlin JVM target accordingly.
  - Standardized Android compile options to Java 24 for consistency.
  - Streamlined build settings by removing deprecated or redundant configuration blocks.
  - Enhanced CI builds with Gradle caching, parallelization, and configuration caching.
  - Added BouncyCastle as a security library dependency.
- Tests
  - No test behavior changes; builds now run with updated toolchain and caching.
- Documentation
  - No user-facing documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->