### PR TITLE
fix(collab-canvas): Add missing material3 dependency

The build was failing with unresolved references to `material3` components in the `collab-canvas` module.

This was caused by the module missing the required `androidx.compose.material3` dependency.

This change adds the dependency to the `collab-canvas/build.gradle.kts` file to resolve the compilation errors.

### DIFF
--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     // Core Android bundles
     implementation(libs.bundles.androidx.core)
     implementation(libs.bundles.compose)
+    implementation(libs.androidx.compose.material3) // Genesis Protocol: Added missing Material 3 dependency
     implementation(libs.bundles.coroutines)
     implementation(libs.bundles.network)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s UI toolkit dependencies to include the latest Material components.
  * Maintenance update to build dependencies for consistency.
  * No user-facing changes in this release; existing screens and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->