### PR TITLE
Diag: Disable KSP in collab-canvas and oracle-drive-integration

This is a diagnostic commit to help debug the build failure. The build
is failing with a `Failed to transform R.jar` error in the `ksp` tasks
for `:collab-canvas` and `:oracle-drive-integration`.

This commit temporarily disables KSP in these two modules by commenting
out the KSP plugin and all `ksp` dependencies.

If the build passes with this change, it will confirm that the root
cause of the issue is related to KSP. If it still fails, the problem
lies elsewhere.

### DIFF
--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
-    id("com.google.devtools.ksp")
+    // id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("org.jetbrains.dokka")
     id("com.diffplug.spotless")
@@ -137,7 +137,7 @@ dependencies {
 
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
+    // ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Core library desugaring
@@ -145,7 +145,7 @@ dependencies {
 
     // Xposed Framework - Complete Integration
     implementation(libs.bundles.xposed)
-    ksp(libs.yuki.ksp.xposed)
+    // ksp(libs.yuki.ksp.xposed)
     implementation(files("${project.rootDir}/Libs/api-82.jar"))
     implementation(files("${project.rootDir}/Libs/api-82-sources.jar"))
 
@@ -159,7 +159,7 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.hilt.android.testing)
-    kspAndroidTest(libs.hilt.compiler)
+    // kspAndroidTest(libs.hilt.compiler)
     androidTestImplementation(libs.androidx.test.core)
 
     // Debug implementations

--- a/oracle-drive-integration/build.gradle.kts
+++ b/oracle-drive-integration/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
-    id("com.google.devtools.ksp")
+    // id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("org.jetbrains.dokka")
     // id("com.diffplug.spotless") // Spotless temporarily disabled
@@ -110,19 +110,19 @@ dependencies {
 
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
+    // ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Room Database
     implementation(libs.bundles.room)
-    ksp(libs.room.compiler)
+    // ksp(libs.room.compiler)
 
     // Core library desugaring
     coreLibraryDesugaring(libs.coreLibraryDesugaring)
 
     // Xposed Framework - Complete Integration
     implementation(libs.bundles.xposed)
-    ksp(libs.yuki.ksp.xposed)
+    // ksp(libs.yuki.ksp.xposed)
     implementation(files("${project.rootDir}/Libs/api-82.jar"))
     implementation(files("${project.rootDir}/Libs/api-82-sources.jar"))
 
@@ -136,7 +136,7 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.hilt.android.testing)
-    kspAndroidTest(libs.hilt.compiler)
+    // kspAndroidTest(libs.hilt.compiler)
     androidTestImplementation(libs.androidx.test.core)
 
     // Debug implementations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a build task that reports environment and configuration status to simplify troubleshooting.

* Chores
  * Disabled annotation processing in select modules to streamline builds and reduce variability.
  * Standardized the Java toolchain to a newer language level for consistent builds across environments.
  * Introduced conditional native build support that auto-enables when native sources are present.

* Refactor
  * Gradle configuration cleaned up to better align with current build tooling and optional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->