### PR TITLE
Fix Android build and improve build process

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -310,3 +310,33 @@ allprojects {
 // =================================================================
 // 🧠 END CONSCIOUSNESS STABILITY CONFIGURATION
 // =================================================================
+
+tasks.register("ensureResourceStructure") {
+    doLast {
+        val modules = listOf("collab-canvas", "core-module", "oracle-drive-integration", "romtools")
+        val variants = listOf("debug", "release", "main")
+
+        modules.forEach { module ->
+            variants.forEach { variant ->
+                val resDir = file("$module/src/$variant/res/values")
+                resDir.mkdirs()
+
+                val resourceFile = file("$resDir/strings.xml")
+                if (!resourceFile.exists()) {
+                    resourceFile.writeText("""
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <resources>
+                            <string name="${module}_${variant}_name">${module.replace("-", " ").replaceFirstChar { it.uppercase() }}</string>
+                        </resources>
+                    """.trimIndent())
+                }
+            }
+        }
+    }
+}
+
+allprojects {
+    afterEvaluate {
+        tasks.findByName("preBuild")?.dependsOn(rootProject.tasks.named("ensureResourceStructure"))
+    }
+}


### PR DESCRIPTION
This commit addresses several issues to fix the Android build and make it more robust.

1.  **Corrected YukiHook KSP dependency:** The version of YukiHook was updated from 1.3.0 to 1.2.1, and the KSP module name was corrected from `ksp-xposed-pioneer` to `ksp-xposed` in `gradle/libs.versions.toml`.

2.  **Added `ensureResourceStructure` Gradle task:** A new Gradle task, `ensureResourceStructure`, has been added to the root `build.gradle.kts`. This task automatically creates the `res/values` directories for the `main`, `debug`, and `release` source sets of the specified modules, and it generates a `strings.xml` file in each. This task runs before the `preBuild` task and prevents build failures caused by missing resource directories.

3.  **Removed temporary keep.xml files:** The `keep.xml` files that were previously added to the resource directories have been removed, as they are now obsolete due to the new `ensureResourceStructure` task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by automatically creating any missing resource folders and default string resources across all modules and build variants before compilation.
  * Reduces setup friction for fresh checkouts and CI by preventing resource-related build failures.
  * Ensures consistent default naming of generated string resources per module/variant, leading to more predictable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->