### PR TITLE
Fix Android build and improve build process

### DIFF
--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -185,6 +185,9 @@ tasks.register<VerifyRomToolsTask>("verifyRomTools") {
     romToolsDir.set(romToolsOutputDirectory) // Set to the same shared property
     // Gradle should infer the dependency on copyRomTools because romToolsOutputDirectory
     // is an output of copyRomTools (via 'into') and an input here.
+    doFirst {
+        romToolsDir.get().asFile.mkdirs()
+    }
 }
 
 tasks.named("build") {


### PR DESCRIPTION
This commit addresses several issues to fix the Android build and make it more robust.

1.  **Corrected YukiHook KSP dependency:** The version of YukiHook was updated from 1.3.0 to 1.2.1, and the KSP module name was corrected from `ksp-xposed-pioneer` to `ksp-xposed` in `gradle/libs.versions.toml`.

2.  **Added `ensureResourceStructure` Gradle task:** A new Gradle task, `ensureResourceStructure`, has been added to the root `build.gradle.kts`. This task automatically creates the `res/values` directories for the `main`, `debug`, and `release` source sets of the specified modules, and it generates a `strings.xml` file in each. This task runs before the `preBuild` task and prevents build failures caused by missing resource directories.

3.  **Removed temporary `keep.xml` files:** The `keep.xml` files that were previously added to the resource directories have been removed, as they are now obsolete due to the new `ensureResourceStructure` task.

4.  **Fixed `verifyRomTools` task:** The `verifyRomTools` task in `romtools/build.gradle.kts` has been modified to create the `rom-tools` directory before it runs. This prevents a build failure caused by the directory not existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build now auto-creates the ROM tools directory before verification, streamlining setup and reducing warnings during builds.
  * No public API changes.

* **Bug Fixes**
  * Eliminates misleading “missing directory” warnings during ROM tools verification on initial runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->