### PR TITLE
Fix Android build and improve build process

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -326,7 +326,7 @@ tasks.register("ensureResourceStructure") {
                     resourceFile.writeText("""
                         <?xml version="1.0" encoding="utf-8"?>
                         <resources>
-                            <string name="${module.replace("-", "_")}_${variant}_name">${module.replace("-", " ").replaceFirstChar { it.uppercase() }}</string>
+                            <string name="${module.replace(Regex("[^A-Za-z0-9]"), "_")}_${variant}_name">${module.replace("-", " ").replaceFirstChar { it.uppercase() }}</string>
                         </resources>
                     """.trimIndent())
                 }


### PR DESCRIPTION
This commit addresses several issues to fix the Android build and make it more robust.

1.  **Corrected YukiHook KSP dependency:** The version of YukiHook was updated from 1.3.0 to 1.2.1, and the KSP module name was corrected from `ksp-xposed-pioneer` to `ksp-xposed` in `gradle/libs.versions.toml`.

2.  **Added `ensureResourceStructure` Gradle task:** A new Gradle task, `ensureResourceStructure`, has been added to the root `build.gradle.kts`. This task automatically creates the `res/values` directories for the `main`, `debug`, and `release` source sets of the specified modules, and it generates a `strings.xml` file in each. This task runs before the `preBuild` task and prevents build failures caused by missing resource directories.

3.  **Removed temporary `keep.xml` files:** The `keep.xml` files that were previously added to the resource directories have been removed, as they are now obsolete due to the new `ensureResourceStructure` task.

4.  **Fixed `verifyRomTools` task dependency:** The `verifyRomTools` task in `romtools/build.gradle.kts` has been modified to explicitly depend on the `copyRomTools` task. This ensures that the required directory is created before the verification task runs, fixing a build failure that was happening during the configuration phase.

5.  **Fixed resource name generation:** The `ensureResourceStructure` task has been updated to use a more robust method to sanitize resource names, replacing all non-alphanumeric characters with underscores. This fixes a build failure caused by invalid characters in resource names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of module names with special characters to prevent invalid resource names, reducing build-time and runtime issues in affected configurations.
  * Ensures labels displayed to users remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->